### PR TITLE
fix: docs links in current tab, remove theme toggle, clickable cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <script defer src="https://a.revisium.io/s.js" data-website-id="a4ec99c0-0b0a-4e24-ba81-84ea1f6f79a1"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/Main/ui/CodeExample/CodeExample.tsx
+++ b/src/pages/Main/ui/CodeExample/CodeExample.tsx
@@ -155,8 +155,6 @@ export const CodeExample: FC<CodeExampleProps> = observer(({ model }) => {
         </Text>
         <Link
           href={model.codeSectionFooterLink}
-          target="_blank"
-          rel="noopener noreferrer"
           display="flex"
           alignItems="center"
           gap="6px"

--- a/src/pages/Main/ui/CtaSection/CtaSection.tsx
+++ b/src/pages/Main/ui/CtaSection/CtaSection.tsx
@@ -24,7 +24,9 @@ export const CtaSection: FC<CtaSectionProps> = observer(({ model }) => {
           {cta.description}
         </Text>
         <Button
-          onClick={() => window.open(cta.ctaLink, '_blank', 'noopener')}
+          onClick={() => {
+            window.location.href = cta.ctaLink
+          }}
           mt="8px"
           px="32px"
           py="14px"

--- a/src/pages/Main/ui/CtaSection/CtaSection.tsx
+++ b/src/pages/Main/ui/CtaSection/CtaSection.tsx
@@ -25,7 +25,7 @@ export const CtaSection: FC<CtaSectionProps> = observer(({ model }) => {
         </Text>
         <Button
           onClick={() => {
-            window.location.href = cta.ctaLink
+            globalThis.location.href = cta.ctaLink
           }}
           mt="8px"
           px="32px"

--- a/src/pages/Main/ui/FeaturesGrid/FeatureCard.tsx
+++ b/src/pages/Main/ui/FeaturesGrid/FeatureCard.tsx
@@ -8,5 +8,5 @@ interface FeatureCardProps {
 }
 
 export const FeatureCard: FC<FeatureCardProps> = ({ title, description, link }) => {
-  return <ContentCard title={title} description={description} link={link} linkLabel={link ? 'Learn more' : undefined} />
+  return <ContentCard title={title} description={description} link={link} />
 }

--- a/src/pages/Main/ui/Header/Header.tsx
+++ b/src/pages/Main/ui/Header/Header.tsx
@@ -3,7 +3,7 @@ import { observer } from 'mobx-react-lite'
 import { FC } from 'react'
 import { LuExternalLink } from 'react-icons/lu'
 import { MainPageModel } from 'src/pages/Main/model/MainPageModel.ts'
-import { ColorModeButton, useColorModeValue } from 'src/shared/ui'
+import { useColorModeValue } from 'src/shared/ui'
 
 interface HeaderProps {
   model: MainPageModel
@@ -61,7 +61,6 @@ export const Header: FC<HeaderProps> = observer(({ model }) => {
           {model.header.githubLabel}
           <LuExternalLink size={16} />
         </Link>
-        <ColorModeButton />
       </Flex>
     </Flex>
   )

--- a/src/pages/Main/ui/HeroSection/HeroSection.tsx
+++ b/src/pages/Main/ui/HeroSection/HeroSection.tsx
@@ -50,7 +50,7 @@ export const HeroSection: FC<HeroSectionProps> = observer(({ model }) => {
       </Text>
       <Button
         onClick={() => {
-          window.location.href = model.hero.ctaLink
+          globalThis.location.href = model.hero.ctaLink
         }}
         mt="8px"
         px="32px"

--- a/src/pages/Main/ui/HeroSection/HeroSection.tsx
+++ b/src/pages/Main/ui/HeroSection/HeroSection.tsx
@@ -49,7 +49,9 @@ export const HeroSection: FC<HeroSectionProps> = observer(({ model }) => {
         {model.hero.description}
       </Text>
       <Button
-        onClick={() => window.open(model.hero.ctaLink, '_blank', 'noopener')}
+        onClick={() => {
+          window.location.href = model.hero.ctaLink
+        }}
         mt="8px"
         px="32px"
         py="14px"

--- a/src/pages/Main/ui/QuickStart/QuickStart.tsx
+++ b/src/pages/Main/ui/QuickStart/QuickStart.tsx
@@ -125,8 +125,6 @@ export const QuickStart: FC<QuickStartProps> = observer(({ model }) => {
       <Flex justify="center" mt="24px">
         <Link
           href={qs.deployLink}
-          target="_blank"
-          rel="noopener noreferrer"
           display="flex"
           alignItems="center"
           gap="6px"

--- a/src/pages/Main/ui/UseCases/UseCaseCard.tsx
+++ b/src/pages/Main/ui/UseCases/UseCaseCard.tsx
@@ -5,9 +5,8 @@ interface UseCaseCardProps {
   title: string
   description: string
   link: string
-  linkLabel: string
 }
 
-export const UseCaseCard: FC<UseCaseCardProps> = ({ title, description, link, linkLabel }) => {
-  return <ContentCard title={title} description={description} link={link} linkLabel={linkLabel} />
+export const UseCaseCard: FC<UseCaseCardProps> = ({ title, description, link }) => {
+  return <ContentCard title={title} description={description} link={link} />
 }

--- a/src/pages/Main/ui/UseCases/UseCases.tsx
+++ b/src/pages/Main/ui/UseCases/UseCases.tsx
@@ -35,7 +35,6 @@ export const UseCases: FC<UseCasesProps> = observer(({ model }) => {
             title={useCase.title}
             description={useCase.description}
             link={useCase.link}
-            linkLabel={useCase.linkLabel}
           />
         ))}
       </Grid>

--- a/src/pages/Main/ui/shared/ContentCard.tsx
+++ b/src/pages/Main/ui/shared/ContentCard.tsx
@@ -1,21 +1,50 @@
 import { Box, Heading, Link, Text } from '@chakra-ui/react'
 import { FC } from 'react'
-import { LuArrowRight } from 'react-icons/lu'
 import { useColorModeValue } from 'src/shared/ui'
 
 interface ContentCardProps {
   title: string
   description: string
   link?: string
-  linkLabel?: string
 }
 
-export const ContentCard: FC<ContentCardProps> = ({ title, description, link, linkLabel }) => {
+export const ContentCard: FC<ContentCardProps> = ({ title, description, link }) => {
   const bg = useColorModeValue('#f9f9f9', '#1a1a1a')
+  const hoverBg = useColorModeValue('#f0f0f0', '#222222')
   const borderColor = useColorModeValue('#e5e5e5', '#2a2a2a')
   const titleColor = useColorModeValue('#171717', '#e5e5e5')
   const descColor = useColorModeValue('#525252', '#a3a3a3')
-  const linkColor = useColorModeValue('#171717', '#e5e5e5')
+
+  const content = (
+    <>
+      <Heading as="h3" fontSize="16px" fontWeight={600} mb="8px" color={titleColor}>
+        {title}
+      </Heading>
+      <Text fontSize="14px" color={descColor} lineHeight={1.5} flex={1}>
+        {description}
+      </Text>
+    </>
+  )
+
+  if (link) {
+    return (
+      <Link
+        href={link}
+        _hover={{ textDecoration: 'none', bg: hoverBg }}
+        p={{ base: '20px', md: '24px' }}
+        borderRadius="12px"
+        border="1px solid"
+        borderColor={borderColor}
+        bg={bg}
+        h="100%"
+        display="flex"
+        flexDirection="column"
+        transition="background 0.2s"
+      >
+        {content}
+      </Link>
+    )
+  }
 
   return (
     <Box
@@ -28,30 +57,7 @@ export const ContentCard: FC<ContentCardProps> = ({ title, description, link, li
       display="flex"
       flexDirection="column"
     >
-      <Heading as="h3" fontSize="16px" fontWeight={600} mb="8px" color={titleColor}>
-        {title}
-      </Heading>
-      <Text fontSize="14px" color={descColor} lineHeight={1.5} flex={1}>
-        {description}
-      </Text>
-      {link && linkLabel && (
-        <Link
-          href={link}
-          target="_blank"
-          rel="noopener noreferrer"
-          display="flex"
-          alignItems="center"
-          gap="4px"
-          fontSize="14px"
-          fontWeight={500}
-          color={linkColor}
-          mt="12px"
-          _hover={{ textDecoration: 'none', gap: '8px' }}
-          transition="gap 0.2s"
-        >
-          {linkLabel} <LuArrowRight size={14} />
-        </Link>
-      )}
+      {content}
     </Box>
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Polished the landing page UX and added Umami analytics. Docs and primary CTAs now open in the current tab, cards are fully clickable, and the theme toggle is removed; external links (e.g., GitHub/Cloud) still open in a new tab.

- **UI/UX**
  - Internal docs and CTA links navigate in the current tab; external links remain new-tab.
  - Content cards are now fully clickable with hover feedback; removed “Learn more” text.
  - Removed the header theme toggle.

- **Dependencies**
  - Added Umami analytics script.

<sup>Written for commit bac54a30f0bad32d29c95f7dfdb8d97d59e4480d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

