### PR TITLE
feat: add hero metrics section

### DIFF
--- a/src/__generated__/graphql-request.ts
+++ b/src/__generated__/graphql-request.ts
@@ -394,8 +394,14 @@ export type LandingMainFlatHero = {
   ctaLabel: Scalars['String']['output'];
   ctaLink: Scalars['String']['output'];
   description: Scalars['String']['output'];
+  metrics: Array<LandingMainFlatHeroMetricsItems>;
   subtitle: Scalars['String']['output'];
   title: Scalars['String']['output'];
+};
+
+export type LandingMainFlatHeroMetricsItems = {
+  label: Scalars['String']['output'];
+  value: Scalars['String']['output'];
 };
 
 export type LandingMainFlatImage = {
@@ -464,8 +470,14 @@ export type LandingMainHero = {
   ctaLabel: Scalars['String']['output'];
   ctaLink: Scalars['String']['output'];
   description: Scalars['String']['output'];
+  metrics: Array<LandingMainHeroMetricsItems>;
   subtitle: Scalars['String']['output'];
   title: Scalars['String']['output'];
+};
+
+export type LandingMainHeroMetricsItems = {
+  label: Scalars['String']['output'];
+  value: Scalars['String']['output'];
 };
 
 export type LandingMainImage = {
@@ -800,7 +812,9 @@ export type UseCaseFragment = { title: string, description: string, link: string
 
 export type CodeStepFragment = { label: string, description: string, title: string, code: string, extraLabel: string, extraCode: string };
 
-export type MainHeroFragment = { title: string, subtitle: string, description: string, ctaLabel: string, ctaLink: string };
+export type MainHeroMetricFragment = { value: string, label: string };
+
+export type MainHeroFragment = { title: string, subtitle: string, description: string, ctaLabel: string, ctaLink: string, metrics: Array<{ value: string, label: string }> };
 
 export type MainHeaderFragment = { docsLink: string, docsLabel: string, githubLink: string, githubLabel: string };
 
@@ -827,8 +841,14 @@ export type MainFooterFragment = { copyright: string, links: Array<{ label: stri
 export type MainPageQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MainPageQuery = { mainFlat: { hero: { title: string, subtitle: string, description: string, ctaLabel: string, ctaLink: string }, image: { url: string, fileId: string, fileName: string, mimeType: string, status: string }, header: { docsLink: string, docsLabel: string, githubLink: string, githubLabel: string }, features: { title: string, items: Array<{ title: string, description: string, link: string }> }, codeSection: { title: string, subtitle: string, footerText: string, footerLink: string, footerLinkLabel: string, items: Array<{ label: string, description: string, title: string, code: string, extraLabel: string, extraCode: string }> }, useCases: { title: string, items: Array<{ title: string, description: string, link: string, linkLabel: string }> }, quickStart: { title: string, standaloneLabel: string, standaloneCmd: string, cloudLabel: string, cloudText: string, cloudLink: string, cloudLinkLabel: string, deployLink: string, deployLinkLabel: string }, openSource: { badge: string, title: string, description: string, link: string, linkLabel: string }, poweredBy: { title: string, description: string, link: string, linkLabel: string }, cta: { title: string, description: string, ctaLabel: string, ctaLink: string }, footer: { copyright: string, links: Array<{ label: string, url: string }> } } };
+export type MainPageQuery = { mainFlat: { hero: { title: string, subtitle: string, description: string, ctaLabel: string, ctaLink: string, metrics: Array<{ value: string, label: string }> }, image: { url: string, fileId: string, fileName: string, mimeType: string, status: string }, header: { docsLink: string, docsLabel: string, githubLink: string, githubLabel: string }, features: { title: string, items: Array<{ title: string, description: string, link: string }> }, codeSection: { title: string, subtitle: string, footerText: string, footerLink: string, footerLinkLabel: string, items: Array<{ label: string, description: string, title: string, code: string, extraLabel: string, extraCode: string }> }, useCases: { title: string, items: Array<{ title: string, description: string, link: string, linkLabel: string }> }, quickStart: { title: string, standaloneLabel: string, standaloneCmd: string, cloudLabel: string, cloudText: string, cloudLink: string, cloudLinkLabel: string, deployLink: string, deployLinkLabel: string }, openSource: { badge: string, title: string, description: string, link: string, linkLabel: string }, poweredBy: { title: string, description: string, link: string, linkLabel: string }, cta: { title: string, description: string, ctaLabel: string, ctaLink: string }, footer: { copyright: string, links: Array<{ label: string, url: string }> } } };
 
+export const MainHeroMetricFragmentDoc = gql`
+    fragment MainHeroMetric on LandingMainFlatHeroMetricsItems {
+  value
+  label
+}
+    `;
 export const MainHeroFragmentDoc = gql`
     fragment MainHero on LandingMainFlatHero {
   title
@@ -836,8 +856,11 @@ export const MainHeroFragmentDoc = gql`
   description
   ctaLabel
   ctaLink
+  metrics {
+    ...MainHeroMetric
+  }
 }
-    `;
+    ${MainHeroMetricFragmentDoc}`;
 export const MainHeaderFragmentDoc = gql`
     fragment MainHeader on LandingMainFlatHeader {
   docsLink

--- a/src/__generated__/schema.graphql
+++ b/src/__generated__/schema.graphql
@@ -385,8 +385,14 @@ type LandingMainFlatHero {
   ctaLabel: String!
   ctaLink: String!
   description: String!
+  metrics: [LandingMainFlatHeroMetricsItems!]!
   subtitle: String!
   title: String!
+}
+
+type LandingMainFlatHeroMetricsItems {
+  label: String!
+  value: String!
 }
 
 type LandingMainFlatImage {
@@ -455,8 +461,14 @@ type LandingMainHero {
   ctaLabel: String!
   ctaLink: String!
   description: String!
+  metrics: [LandingMainHeroMetricsItems!]!
   subtitle: String!
   title: String!
+}
+
+type LandingMainHeroMetricsItems {
+  label: String!
+  value: String!
 }
 
 type LandingMainImage {

--- a/src/pages/Main/api/main.graphql
+++ b/src/pages/Main/api/main.graphql
@@ -20,12 +20,20 @@ fragment CodeStep on LandingCode_stepFlat {
   extraCode
 }
 
+fragment MainHeroMetric on LandingMainFlatHeroMetricsItems {
+  value
+  label
+}
+
 fragment MainHero on LandingMainFlatHero {
   title
   subtitle
   description
   ctaLabel
   ctaLink
+  metrics {
+    ...MainHeroMetric
+  }
 }
 
 fragment MainHeader on LandingMainFlatHeader {

--- a/src/pages/Main/ui/HeroSection/HeroSection.tsx
+++ b/src/pages/Main/ui/HeroSection/HeroSection.tsx
@@ -13,6 +13,8 @@ interface HeroSectionProps {
 export const HeroSection: FC<HeroSectionProps> = observer(({ model }) => {
   const textColor = useColorModeValue('#171717', '#e5e5e5')
   const descColor = useColorModeValue('#525252', '#a3a3a3')
+  const mutedColor = useColorModeValue('#737373', '#525252')
+  const borderColor = useColorModeValue('#e5e5e5', '#262626')
   const chevronColor = useColorModeValue('#a3a3a3', '#525252')
 
   const BOUNCE_DISTANCE = 6
@@ -59,6 +61,28 @@ export const HeroSection: FC<HeroSectionProps> = observer(({ model }) => {
       >
         {model.hero.ctaLabel}
       </Button>
+
+      <Flex
+        gap={{ base: '24px', md: '48px' }}
+        mt={{ base: '24px', md: '32px' }}
+        pt={{ base: '24px', md: '32px' }}
+        borderTop="1px solid"
+        borderColor={borderColor}
+        flexDirection={{ base: 'column', md: 'row' }}
+        alignItems={{ base: 'center', md: 'flex-start' }}
+      >
+        {model.hero.metrics.map((metric) => (
+          <Flex key={metric.label} flexDirection="column" alignItems="center" gap="4px">
+            <Text fontSize={{ base: '28px', md: '32px' }} fontWeight={700} color={textColor} lineHeight={1.2}>
+              {metric.value}
+            </Text>
+            <Text fontSize={{ base: '13px', md: '14px' }} color={mutedColor} fontWeight={400}>
+              {metric.label}
+            </Text>
+          </Flex>
+        ))}
+      </Flex>
+
       <motion.div
         aria-hidden="true"
         initial={{ opacity: 0 }}


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a metrics strip to the hero that shows key stats below the CTA. Data comes from `hero.metrics` and the UI is responsive with dark mode styles.

- **New Features**
  - Renders metric value + label under the CTA; 3 columns on desktop, stacked on mobile.
  - Adds light/dark text colors and a top border for the metrics block.
  - Extends GraphQL: adds `metrics` to `LandingMainFlatHero`/`LandingMainHero`, introduces `MainHeroMetric` fragment, and includes `metrics` in `MainPageQuery` with updated generated types.

<sup>Written for commit e0edf775e9eef273627d55e34ff0f6e0064d3a9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

